### PR TITLE
Implement Basic MCP Server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="mcp_pokemon",
+    version="0.1.0",
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    install_requires=[
+        "mcp>=1.6.0",
+        "uvicorn[standard]>=0.24.0",
+        "fastapi>=0.104.1",
+        "httpx>=0.25.1",
+        "python-dotenv>=1.0.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.4.3",
+            "pytest-cov>=4.1.0",
+            "black>=23.12.0",
+            "isort>=5.13.0",
+            "mypy>=1.7.0",
+            "ruff>=0.1.6",
+        ]
+    },
+) 

--- a/src/mcp_pokemon/api/errors.py
+++ b/src/mcp_pokemon/api/errors.py
@@ -1,0 +1,67 @@
+from typing import Any, Dict, Optional
+
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import HTTPException
+
+
+class MCPPokemonError(Exception):
+    """Base exception for MCP Pokemon service"""
+    def __init__(
+        self,
+        message: str,
+        status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+        details: Optional[Dict[str, Any]] = None
+    ):
+        self.message = message
+        self.status_code = status_code
+        self.details = details or {}
+        super().__init__(self.message)
+
+
+class NotFoundError(MCPPokemonError):
+    """Raised when a requested resource is not found"""
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(
+            message=message,
+            status_code=status.HTTP_404_NOT_FOUND,
+            details=details
+        )
+
+
+class ValidationError(MCPPokemonError):
+    """Raised when input validation fails"""
+    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None):
+        super().__init__(
+            message=message,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            details=details
+        )
+
+
+async def mcp_pokemon_error_handler(request: Request, exc: MCPPokemonError) -> JSONResponse:
+    """Handler for MCP Pokemon custom exceptions"""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "error": {
+                "type": exc.__class__.__name__,
+                "message": exc.message,
+                "details": exc.details
+            }
+        }
+    )
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Handler for FastAPI HTTP exceptions"""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "error": {
+                "type": "HTTPException",
+                "message": str(exc.detail),
+                "details": {}
+            }
+        }
+    ) 

--- a/src/mcp_pokemon/api/logging.py
+++ b/src/mcp_pokemon/api/logging.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 class JSONFormatter(logging.Formatter):
@@ -16,7 +16,7 @@ class JSONFormatter(logging.Formatter):
         """Format the log record as JSON"""
         # Base log data
         log_data = {
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": record.levelname,
             "message": record.getMessage(),
             "module": record.module,

--- a/src/mcp_pokemon/api/logging.py
+++ b/src/mcp_pokemon/api/logging.py
@@ -1,0 +1,113 @@
+import json
+import logging
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any, Dict, Optional
+
+class JSONFormatter(logging.Formatter):
+    """Custom formatter that outputs logs as JSON"""
+    
+    def __init__(self, service: str, environment: str):
+        super().__init__()
+        self.service = service
+        self.environment = environment
+    
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record as JSON"""
+        # Base log data
+        log_data = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "service": self.service,
+            "environment": self.environment
+        }
+        
+        # Add exception info if present
+        if record.exc_info:
+            exc_type, exc_value, exc_tb = record.exc_info
+            log_data["exception"] = {
+                "type": exc_type.__name__,
+                "message": str(exc_value),
+                "traceback": self.formatException(record.exc_info)
+            }
+        
+        # Add extra fields from record
+        if hasattr(record, "extra"):
+            log_data.update(record.extra)
+        
+        # Add any additional attributes from the record
+        for key, value in record.__dict__.items():
+            if (
+                key not in {
+                    "args", "asctime", "created", "exc_info", "exc_text",
+                    "filename", "funcName", "levelname", "levelno", "lineno",
+                    "module", "msecs", "msg", "name", "pathname", "process",
+                    "processName", "relativeCreated", "stack_info", "thread",
+                    "threadName", "extra"
+                }
+                and not key.startswith("_")
+            ):
+                log_data[key] = value
+        
+        return json.dumps(log_data)
+
+class LoggerAdapter(logging.LoggerAdapter):
+    """Adapter that adds extra fields to log records"""
+    
+    def __init__(self, logger: logging.Logger, extra: Dict[str, Any]):
+        # If logger is already an adapter, merge its extra fields
+        if isinstance(logger, LoggerAdapter):
+            extra = {**logger.extra, **extra}
+            logger = logger.logger
+        super().__init__(logger, extra or {})
+    
+    def process(self, msg: str, kwargs: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
+        """Process the logging message and keyword arguments"""
+        kwargs.setdefault("extra", {}).update(self.extra)
+        return msg, kwargs
+
+@contextmanager
+def LoggerContext(logger: logging.Logger, **context_fields: Any):
+    """Context manager for adding temporary fields to log records"""
+    if isinstance(logger, LoggerAdapter):
+        # Create new adapter with merged fields
+        new_extra = {**logger.extra, **context_fields}
+        new_logger = LoggerAdapter(logger.logger, new_extra)
+    else:
+        # Create new adapter with context fields
+        new_logger = LoggerAdapter(logger, context_fields)
+    
+    try:
+        yield new_logger
+    finally:
+        pass
+
+def setup_logging(
+    level: str = "INFO",
+    service_name: str = "mcp-pokemon",
+    environment: str = "development"
+) -> None:
+    """Set up logging configuration"""
+    # Get the root logger
+    root_logger = logging.getLogger()
+    
+    # Set log level
+    root_logger.setLevel(getattr(logging, level.upper()))
+    
+    # Remove existing handlers
+    root_logger.handlers = []
+    
+    # Create console handler with JSON formatter
+    console_handler = logging.StreamHandler()
+    formatter = JSONFormatter(service=service_name, environment=environment)
+    console_handler.setFormatter(formatter)
+    
+    # Add handler to root logger
+    root_logger.addHandler(console_handler)
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a logger instance"""
+    return logging.getLogger(name) 

--- a/src/mcp_pokemon/api/main.py
+++ b/src/mcp_pokemon/api/main.py
@@ -1,5 +1,7 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
 
 from mcp_pokemon.api.errors import (
     MCPPokemonError,
@@ -8,13 +10,45 @@ from mcp_pokemon.api.errors import (
     mcp_pokemon_error_handler,
     http_exception_handler
 )
+from mcp_pokemon.api.logging import setup_logging, get_logger
+from mcp_pokemon.api.middleware import RequestLoggingMiddleware
+
+# Setup logging
+setup_logging(level="INFO")
+logger = get_logger(__name__)
 
 # Create FastAPI app
 app = FastAPI(
     title="MCP Pokemon",
-    description="A Pokemon-focused implementation of the Model Context Protocol (MCP)",
-    version="0.1.0"
+    description="""
+    A Pokemon-focused implementation of the Model Context Protocol (MCP).
+    
+    This API provides:
+    - Health check endpoint for monitoring
+    - Pokemon information endpoints
+    - MCP server integration for real-time updates
+    
+    All endpoints are logged with structured JSON logging, including:
+    - Request/response details
+    - Performance metrics
+    - Error tracking
+    """,
+    version="0.1.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+    contact={
+        "name": "MCP Pokemon Team",
+        "url": "https://github.com/danielfranca/MCP_Pokemon",
+    },
+    license_info={
+        "name": "MIT",
+        "url": "https://opensource.org/licenses/MIT",
+    }
 )
+
+# Add middleware
+app.add_middleware(RequestLoggingMiddleware)
 
 # Register error handlers
 app.add_exception_handler(MCPPokemonError, mcp_pokemon_error_handler)
@@ -26,17 +60,120 @@ mcp = FastMCP("MCP Pokemon")
 # Mount MCP server to FastAPI app at /mcp path
 app.mount("/mcp", mcp.sse_app())
 
+# Response models
+class HealthResponse(BaseModel):
+    """Health check response model"""
+    status: str = Field(
+        description="Current health status of the service",
+        example="healthy"
+    )
+    service: str = Field(
+        description="Name of the service",
+        example="mcp-pokemon"
+    )
+
+class PokemonResponse(BaseModel):
+    """Pokemon details response model"""
+    id: int = Field(
+        description="The unique identifier of the Pokemon",
+        example=25,
+        gt=0
+    )
+    name: str = Field(
+        description="The name of the Pokemon",
+        example="Pikachu"
+    )
+
+class TeamResponse(BaseModel):
+    """Pokemon team response model"""
+    team_name: str = Field(
+        description="Name of the Pokemon team",
+        example="Elite Four"
+    )
+    pokemon_ids: list[int] = Field(
+        description="List of Pokemon IDs in the team",
+        example=[25, 6, 149, 130, 59, 131],
+        min_items=1,
+        max_items=6
+    )
+
+class EvolutionResponse(BaseModel):
+    """Pokemon evolution chain response model"""
+    evolution_chain: list[int] = Field(
+        description="List of Pokemon IDs in the evolution chain",
+        example=[172, 25, 26]
+    )
+
 # Health check endpoint
-@app.get("/health")
+@app.get(
+    "/health",
+    response_model=HealthResponse,
+    tags=["System"],
+    summary="Service health check",
+    description="Returns the current health status of the service",
+    response_description="Health status information"
+)
 async def health_check():
     """Health check endpoint"""
+    logger.info("Health check requested")
     return {"status": "healthy", "service": "mcp-pokemon"}
 
 # Example endpoints demonstrating error handling
-@app.get("/pokemon/{pokemon_id}")
+@app.get(
+    "/pokemon/{pokemon_id}",
+    response_model=PokemonResponse,
+    tags=["Pokemon"],
+    summary="Get Pokemon details",
+    description="""
+    Retrieves details for a specific Pokemon by its ID.
+    
+    The Pokemon ID must be a positive integer.
+    Returns a 404 error if the Pokemon is not found (ID > 1000).
+    Returns a 422 error if the ID is not positive.
+    """,
+    responses={
+        404: {
+            "description": "Pokemon not found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "type": "NotFoundError",
+                            "message": "Pokemon with ID 1001 not found",
+                            "details": {"pokemon_id": 1001}
+                        }
+                    }
+                }
+            }
+        },
+        422: {
+            "description": "Validation error",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "type": "ValidationError",
+                            "message": "Pokemon ID must be positive",
+                            "details": {
+                                "pokemon_id": 0,
+                                "constraint": "positive_integer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+)
 async def get_pokemon(pokemon_id: int):
     """Example endpoint demonstrating NotFoundError"""
+    logger.info(f"Getting Pokemon details", extra={"pokemon_id": pokemon_id})
+    
     if pokemon_id <= 0:
+        logger.warning(
+            "Invalid Pokemon ID provided",
+            extra={"pokemon_id": pokemon_id, "error": "non_positive_id"}
+        )
         raise ValidationError(
             message="Pokemon ID must be positive",
             details={"pokemon_id": pokemon_id, "constraint": "positive_integer"}
@@ -44,22 +181,76 @@ async def get_pokemon(pokemon_id: int):
     
     # Simulating a not found scenario for IDs > 1000
     if pokemon_id > 1000:
+        logger.warning(
+            "Pokemon not found",
+            extra={"pokemon_id": pokemon_id, "error": "not_found"}
+        )
         raise NotFoundError(
             message=f"Pokemon with ID {pokemon_id} not found",
             details={"pokemon_id": pokemon_id}
         )
     
     # Simulating a successful response
+    logger.info(
+        "Pokemon details retrieved",
+        extra={"pokemon_id": pokemon_id}
+    )
     return {"id": pokemon_id, "name": "Example Pokemon"}
 
-@app.post("/pokemon/team")
+@app.post(
+    "/pokemon/team",
+    response_model=TeamResponse,
+    tags=["Pokemon"],
+    summary="Create a Pokemon team",
+    description="""
+    Creates a new Pokemon team with the given name and Pokemon IDs.
+    
+    Requirements:
+    - Team name must be at least 3 characters long
+    - Team must have between 1 and 6 Pokemon
+    - All Pokemon IDs must be positive
+    - No duplicate Pokemon allowed in the team
+    """,
+    responses={
+        422: {
+            "description": "Validation error",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "type": "ValidationError",
+                            "message": "Invalid Pokemon IDs in team",
+                            "details": {
+                                "invalid_ids": [0, -1],
+                                "constraint": "all_ids_must_be_positive"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+)
 async def create_team(
     team_name: str = Query(..., min_length=3),
     pokemon_ids: list[int] = Query(..., min_items=1, max_items=6)
 ):
     """Example endpoint demonstrating ValidationError with multiple validation rules"""
+    logger.info(
+        "Creating Pokemon team",
+        extra={"team_name": team_name, "pokemon_ids": pokemon_ids}
+    )
+    
     invalid_ids = [pid for pid in pokemon_ids if pid <= 0]
     if invalid_ids:
+        logger.warning(
+            "Invalid Pokemon IDs in team",
+            extra={
+                "team_name": team_name,
+                "invalid_ids": invalid_ids,
+                "error": "invalid_pokemon_ids"
+            }
+        )
         raise ValidationError(
             message="Invalid Pokemon IDs in team",
             details={
@@ -69,6 +260,14 @@ async def create_team(
         )
     
     if len(set(pokemon_ids)) != len(pokemon_ids):
+        logger.warning(
+            "Duplicate Pokemon in team",
+            extra={
+                "team_name": team_name,
+                "pokemon_ids": pokemon_ids,
+                "error": "duplicate_pokemon"
+            }
+        )
         raise ValidationError(
             message="Duplicate Pokemon in team",
             details={
@@ -77,15 +276,62 @@ async def create_team(
             }
         )
     
+    logger.info(
+        "Team created successfully",
+        extra={"team_name": team_name, "pokemon_ids": pokemon_ids}
+    )
     return {
         "team_name": team_name,
         "pokemon_ids": pokemon_ids
     }
 
-@app.get("/pokemon/{pokemon_id}/evolution")
+@app.get(
+    "/pokemon/{pokemon_id}/evolution",
+    response_model=EvolutionResponse,
+    tags=["Pokemon"],
+    summary="Get Pokemon evolution chain",
+    description="""
+    Retrieves the evolution chain for a specific Pokemon.
+    
+    This endpoint demonstrates internal error handling.
+    For demonstration purposes, it will return an error for Pokemon ID 0.
+    """,
+    responses={
+        500: {
+            "description": "Internal server error",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "type": "MCPPokemonError",
+                            "message": "Failed to fetch evolution data",
+                            "details": {
+                                "pokemon_id": 0,
+                                "error_source": "evolution_service",
+                                "error_code": "INTERNAL_ERROR"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+)
 async def get_pokemon_evolution(pokemon_id: int):
     """Example endpoint demonstrating internal server error handling"""
+    logger.info(
+        "Getting Pokemon evolution chain",
+        extra={"pokemon_id": pokemon_id}
+    )
+    
     if pokemon_id == 0:
+        logger.error(
+            "Evolution service error",
+            extra={
+                "pokemon_id": pokemon_id,
+                "error": "evolution_service_error"
+            }
+        )
         # Simulating an unexpected internal error
         raise MCPPokemonError(
             message="Failed to fetch evolution data",
@@ -95,6 +341,14 @@ async def get_pokemon_evolution(pokemon_id: int):
                 "error_code": "INTERNAL_ERROR"
             }
         )
+    
+    logger.info(
+        "Evolution chain retrieved",
+        extra={
+            "pokemon_id": pokemon_id,
+            "evolution_chain": [pokemon_id, pokemon_id + 1]
+        }
+    )
     return {"evolution_chain": [pokemon_id, pokemon_id + 1]}
 
 # Basic MCP resource example

--- a/src/mcp_pokemon/api/main.py
+++ b/src/mcp_pokemon/api/main.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI
+from mcp.server.fastmcp import FastMCP
+
+# Create FastAPI app
+app = FastAPI(
+    title="MCP Pokemon",
+    description="A Pokemon-focused implementation of the Model Context Protocol (MCP)",
+    version="0.1.0"
+)
+
+# Create MCP server instance
+mcp = FastMCP("MCP Pokemon")
+
+# Mount MCP server to FastAPI app at /mcp path
+app.mount("/mcp", mcp.sse_app())
+
+# Health check endpoint
+@app.get("/health")
+async def health_check():
+    """Health check endpoint"""
+    return {"status": "healthy", "service": "mcp-pokemon"}
+
+# Basic MCP resource example
+@mcp.resource("status://health")
+async def status_resource() -> str:
+    """Provide the service status as a resource"""
+    return "MCP Pokemon service is running"
+
+# Basic MCP tool example
+@mcp.tool()
+async def get_service_info() -> dict:
+    """Get basic service information"""
+    return {
+        "name": "MCP Pokemon",
+        "version": "0.1.0",
+        "status": "running",
+        "description": "Pokemon data service using Model Context Protocol"
+    }
+
+# Basic MCP prompt example
+@mcp.prompt()
+async def help_prompt() -> str:
+    """Create a help prompt for the service"""
+    return """
+    Welcome to the MCP Pokemon service!
+    
+    This service provides Pokemon information through the Model Context Protocol.
+    You can:
+    - Use resources to access Pokemon data
+    - Use tools to query and analyze Pokemon information
+    - Use prompts to get help and guidance
+    
+    How can I assist you with Pokemon information today?
+    """ 

--- a/src/mcp_pokemon/api/main.py
+++ b/src/mcp_pokemon/api/main.py
@@ -1,5 +1,13 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
 from mcp.server.fastmcp import FastMCP
+
+from mcp_pokemon.api.errors import (
+    MCPPokemonError,
+    NotFoundError,
+    ValidationError,
+    mcp_pokemon_error_handler,
+    http_exception_handler
+)
 
 # Create FastAPI app
 app = FastAPI(
@@ -7,6 +15,10 @@ app = FastAPI(
     description="A Pokemon-focused implementation of the Model Context Protocol (MCP)",
     version="0.1.0"
 )
+
+# Register error handlers
+app.add_exception_handler(MCPPokemonError, mcp_pokemon_error_handler)
+app.add_exception_handler(HTTPException, http_exception_handler)
 
 # Create MCP server instance
 mcp = FastMCP("MCP Pokemon")
@@ -19,6 +31,71 @@ app.mount("/mcp", mcp.sse_app())
 async def health_check():
     """Health check endpoint"""
     return {"status": "healthy", "service": "mcp-pokemon"}
+
+# Example endpoints demonstrating error handling
+@app.get("/pokemon/{pokemon_id}")
+async def get_pokemon(pokemon_id: int):
+    """Example endpoint demonstrating NotFoundError"""
+    if pokemon_id <= 0:
+        raise ValidationError(
+            message="Pokemon ID must be positive",
+            details={"pokemon_id": pokemon_id, "constraint": "positive_integer"}
+        )
+    
+    # Simulating a not found scenario for IDs > 1000
+    if pokemon_id > 1000:
+        raise NotFoundError(
+            message=f"Pokemon with ID {pokemon_id} not found",
+            details={"pokemon_id": pokemon_id}
+        )
+    
+    # Simulating a successful response
+    return {"id": pokemon_id, "name": "Example Pokemon"}
+
+@app.post("/pokemon/team")
+async def create_team(
+    team_name: str = Query(..., min_length=3),
+    pokemon_ids: list[int] = Query(..., min_items=1, max_items=6)
+):
+    """Example endpoint demonstrating ValidationError with multiple validation rules"""
+    invalid_ids = [pid for pid in pokemon_ids if pid <= 0]
+    if invalid_ids:
+        raise ValidationError(
+            message="Invalid Pokemon IDs in team",
+            details={
+                "invalid_ids": invalid_ids,
+                "constraint": "all_ids_must_be_positive"
+            }
+        )
+    
+    if len(set(pokemon_ids)) != len(pokemon_ids):
+        raise ValidationError(
+            message="Duplicate Pokemon in team",
+            details={
+                "pokemon_ids": pokemon_ids,
+                "constraint": "unique_pokemon_only"
+            }
+        )
+    
+    return {
+        "team_name": team_name,
+        "pokemon_ids": pokemon_ids
+    }
+
+@app.get("/pokemon/{pokemon_id}/evolution")
+async def get_pokemon_evolution(pokemon_id: int):
+    """Example endpoint demonstrating internal server error handling"""
+    if pokemon_id == 0:
+        # Simulating an unexpected internal error
+        raise MCPPokemonError(
+            message="Failed to fetch evolution data",
+            details={
+                "pokemon_id": pokemon_id,
+                "error_source": "evolution_service",
+                "error_code": "INTERNAL_ERROR"
+            }
+        )
+    return {"evolution_chain": [pokemon_id, pokemon_id + 1]}
 
 # Basic MCP resource example
 @mcp.resource("status://health")

--- a/src/mcp_pokemon/api/main.py
+++ b/src/mcp_pokemon/api/main.py
@@ -39,7 +39,7 @@ app = FastAPI(
     openapi_url="/openapi.json",
     contact={
         "name": "MCP Pokemon Team",
-        "url": "https://github.com/danielfranca/MCP_Pokemon",
+        "url": "https://github.com/danielyoshizawa/MCP_Pokemon",
     },
     license_info={
         "name": "MIT",

--- a/tests/api/test_endpoints.py
+++ b/tests/api/test_endpoints.py
@@ -1,0 +1,107 @@
+from fastapi import status
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_pokemon.api.main import app
+
+client = TestClient(app)
+
+def test_get_pokemon_success():
+    """Test successful Pokemon retrieval"""
+    response = client.get("/pokemon/1")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"id": 1, "name": "Example Pokemon"}
+
+def test_get_pokemon_validation_error():
+    """Test validation error for invalid Pokemon ID"""
+    response = client.get("/pokemon/-1")
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+        "error": {
+            "type": "ValidationError",
+            "message": "Pokemon ID must be positive",
+            "details": {"pokemon_id": -1, "constraint": "positive_integer"}
+        }
+    }
+
+def test_get_pokemon_not_found():
+    """Test not found error for non-existent Pokemon"""
+    response = client.get("/pokemon/1001")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "error": {
+            "type": "NotFoundError",
+            "message": "Pokemon with ID 1001 not found",
+            "details": {"pokemon_id": 1001}
+        }
+    }
+
+def test_create_team_success():
+    """Test successful team creation"""
+    response = client.post("/pokemon/team", params={
+        "team_name": "Test Team",
+        "pokemon_ids": [1, 2, 3]
+    })
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "team_name": "Test Team",
+        "pokemon_ids": [1, 2, 3]
+    }
+
+def test_create_team_invalid_ids():
+    """Test validation error for invalid Pokemon IDs in team"""
+    response = client.post("/pokemon/team", params={
+        "team_name": "Invalid Team",
+        "pokemon_ids": [1, -1, 0]
+    })
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+        "error": {
+            "type": "ValidationError",
+            "message": "Invalid Pokemon IDs in team",
+            "details": {
+                "invalid_ids": [-1, 0],
+                "constraint": "all_ids_must_be_positive"
+            }
+        }
+    }
+
+def test_create_team_duplicate_pokemon():
+    """Test validation error for duplicate Pokemon in team"""
+    response = client.post("/pokemon/team", params={
+        "team_name": "Duplicate Team",
+        "pokemon_ids": [1, 2, 2]
+    })
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+        "error": {
+            "type": "ValidationError",
+            "message": "Duplicate Pokemon in team",
+            "details": {
+                "pokemon_ids": [1, 2, 2],
+                "constraint": "unique_pokemon_only"
+            }
+        }
+    }
+
+def test_get_evolution_success():
+    """Test successful evolution chain retrieval"""
+    response = client.get("/pokemon/1/evolution")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"evolution_chain": [1, 2]}
+
+def test_get_evolution_internal_error():
+    """Test internal server error in evolution endpoint"""
+    response = client.get("/pokemon/0/evolution")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == {
+        "error": {
+            "type": "MCPPokemonError",
+            "message": "Failed to fetch evolution data",
+            "details": {
+                "pokemon_id": 0,
+                "error_source": "evolution_service",
+                "error_code": "INTERNAL_ERROR"
+            }
+        }
+    } 

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -1,0 +1,87 @@
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from mcp_pokemon.api.errors import (
+    MCPPokemonError,
+    NotFoundError,
+    ValidationError,
+    mcp_pokemon_error_handler,
+    http_exception_handler
+)
+
+# Test app setup
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.add_exception_handler(MCPPokemonError, mcp_pokemon_error_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    return app
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+# Test routes that raise different exceptions
+def test_mcp_pokemon_error(app, client):
+    @app.get("/test-base-error")
+    async def raise_base_error():
+        raise MCPPokemonError("Test base error", details={"test": "detail"})
+    
+    response = client.get("/test-base-error")
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json() == {
+        "error": {
+            "type": "MCPPokemonError",
+            "message": "Test base error",
+            "details": {"test": "detail"}
+        }
+    }
+
+def test_not_found_error(app, client):
+    @app.get("/test-not-found")
+    async def raise_not_found():
+        raise NotFoundError("Resource not found", details={"resource_id": "123"})
+    
+    response = client.get("/test-not-found")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "error": {
+            "type": "NotFoundError",
+            "message": "Resource not found",
+            "details": {"resource_id": "123"}
+        }
+    }
+
+def test_validation_error(app, client):
+    @app.get("/test-validation")
+    async def raise_validation():
+        raise ValidationError("Invalid input", details={"field": "name", "error": "required"})
+    
+    response = client.get("/test-validation")
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+        "error": {
+            "type": "ValidationError",
+            "message": "Invalid input",
+            "details": {"field": "name", "error": "required"}
+        }
+    }
+
+def test_http_exception(app, client):
+    @app.get("/test-http-error")
+    async def raise_http_error():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized"
+        )
+    
+    response = client.get("/test-http-error")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "error": {
+            "type": "HTTPException",
+            "message": "Not authorized",
+            "details": {}
+        }
+    } 

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from io import StringIO
+from typing import Any, Dict
+
+import pytest
+
+from mcp_pokemon.api.logging import JSONFormatter, LoggerContext, setup_logging
+
+@pytest.fixture
+def string_stream():
+    """Create a string stream for capturing log output"""
+    return StringIO()
+
+@pytest.fixture
+def json_logger(string_stream):
+    """Create a logger with JSON formatting"""
+    logger = logging.getLogger("test_logger")
+    logger.setLevel(logging.INFO)
+    
+    # Clear any existing handlers
+    logger.handlers = []
+    
+    # Create handler with string stream
+    handler = logging.StreamHandler(string_stream)
+    formatter = JSONFormatter(service="test-service", environment="test")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    
+    return logger
+
+def get_log_entry(stream: StringIO) -> Dict[str, Any]:
+    """Parse the last log entry from the stream"""
+    return json.loads(stream.getvalue().strip().split("\n")[-1])
+
+def test_json_formatter(json_logger, string_stream):
+    """Test that logs are properly formatted as JSON"""
+    json_logger.info("Test message", extra={"test_field": "test_value"})
+    
+    log_entry = get_log_entry(string_stream)
+    
+    assert log_entry["message"] == "Test message"
+    assert log_entry["level"] == "INFO"
+    assert log_entry["service"] == "test-service"
+    assert log_entry["environment"] == "test"
+    assert log_entry["test_field"] == "test_value"
+    assert "timestamp" in log_entry
+
+def test_logger_context(json_logger, string_stream):
+    """Test that LoggerContext properly manages contextual log fields"""
+    with LoggerContext(json_logger, request_id="123", user_id="456") as logger:
+        logger.info("Test with context")
+    
+    json_logger.info("Test without context")
+    
+    log_entries = string_stream.getvalue().strip().split("\n")
+    with_context = json.loads(log_entries[0])
+    without_context = json.loads(log_entries[1])
+    
+    assert with_context["request_id"] == "123"
+    assert with_context["user_id"] == "456"
+    assert "request_id" not in without_context
+    assert "user_id" not in without_context
+
+def test_nested_logger_context(json_logger, string_stream):
+    """Test nested LoggerContext behavior"""
+    with LoggerContext(json_logger, outer="outer_value") as outer_logger:
+        outer_logger.info("Outer context")
+        
+        with LoggerContext(outer_logger, inner="inner_value") as inner_logger:
+            inner_logger.info("Inner context")
+        
+        outer_logger.info("Back to outer")
+    
+    log_entries = string_stream.getvalue().strip().split("\n")
+    outer_log = json.loads(log_entries[0])
+    inner_log = json.loads(log_entries[1])
+    back_to_outer = json.loads(log_entries[2])
+    
+    assert outer_log["outer"] == "outer_value"
+    assert "inner" not in outer_log
+    
+    assert inner_log["outer"] == "outer_value"
+    assert inner_log["inner"] == "inner_value"
+    
+    assert back_to_outer["outer"] == "outer_value"
+    assert "inner" not in back_to_outer
+
+def test_exception_logging(json_logger, string_stream):
+    """Test that exceptions are properly logged"""
+    try:
+        raise ValueError("Test error")
+    except ValueError:
+        json_logger.error("Error occurred", exc_info=True)
+    
+    log_entry = get_log_entry(string_stream)
+    
+    assert log_entry["level"] == "ERROR"
+    assert log_entry["message"] == "Error occurred"
+    assert log_entry["exception"]["type"] == "ValueError"
+    assert log_entry["exception"]["message"] == "Test error"
+    assert "traceback" in log_entry["exception"]
+
+def test_setup_logging():
+    """Test logging setup function"""
+    # Capture initial handlers
+    root_logger = logging.getLogger()
+    initial_handlers = root_logger.handlers.copy()
+    
+    try:
+        setup_logging(
+            level="DEBUG",
+            service_name="test-service",
+            environment="test"
+        )
+        
+        # Verify logger configuration
+        assert root_logger.level == logging.DEBUG
+        assert len(root_logger.handlers) == 1
+        
+        handler = root_logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert isinstance(handler.formatter, JSONFormatter)
+        
+    finally:
+        # Restore initial handlers
+        root_logger.handlers = initial_handlers 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from mcp_pokemon.api.main import app
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI application"""
+    return TestClient(app) 


### PR DESCRIPTION
This PR implements the basic MCP server functionality as described in Issue #2.

Changes include:
- Created `main.py` in the api directory
- Implemented basic MCP server configuration
- Added health check endpoint
- Added basic error handling with custom error classes
- Added comprehensive logging system with JSON formatting
- Added request logging middleware
- Tested server startup and basic functionality
- Added detailed OpenAPI documentation for all endpoints

All tasks from Issue #2 have been completed and tested:
- ✅ Create `main.py` in the api directory
- ✅ Implement basic MCP server configuration
- ✅ Add health check endpoint
- ✅ Add basic error handling
- ✅ Add logging configuration
- ✅ Test server startup and basic functionality
- ✅ Document API endpoints

The server can now be accessed at:
- API: http://localhost:8000
- Swagger UI: http://localhost:8000/docs
- ReDoc: http://localhost:8000/redoc
- OpenAPI JSON: http://localhost:8000/openapi.json

Closes #2